### PR TITLE
Add combo example and fixes AlarmMgr

### DIFF
--- a/workspace/em.core/em.examples.advanced/ButtonFiberLedPrintTickerTimeP.em.zig
+++ b/workspace/em.core/em.examples.advanced/ButtonFiberLedPrintTickerTimeP.em.zig
@@ -31,6 +31,7 @@ pub const EM__TARG = struct {
 
     const maxSysLedTicks: u32 = 384; // 1.5s
     const maxAppLedTicks: u32 = 512; // 2s
+    const printLedTicks: u32 = 1280; // 5s
     const minPressTime = 10; // 10ms
     const maxPressTime = 2000; // 2s
     var dividedBy: u32 = 1;
@@ -45,7 +46,7 @@ pub const EM__TARG = struct {
         AppBut.onPressed(onButtonPressed, .{ .min = minPressTime, .max = maxPressTime });
         appTicker.start(maxAppLedTicks, &appTickCb);
         sysTicker.start(maxSysLedTicks, &sysTickCb);
-        printTicker.start(1024, &printTickCb);
+        printTicker.start(printLedTicks, &printTickCb);
         FiberMgr.run();
     }
 
@@ -63,7 +64,7 @@ pub const EM__TARG = struct {
         printCount += 1;
         var subSeconds: u32 = 0;
         const seconds = EpochTime.getCurrent(&subSeconds);
-        em.print("{}: Hello World: Rate={}x appCount={} sysCount={}\n", .{ seconds, dividedBy, appCount, sysCount });
+        em.print("{}.{}: Hello World: Rate={}x appCount={} sysCount={}\n", .{ seconds, subSeconds, dividedBy, appCount, sysCount });
         if (dividedBy > 0 and lastSysCount > 0 and lastSysCount == sysCount) {
             em.print("Sys ticker count did not increment\n", .{});
             em.halt();

--- a/workspace/em.core/em.examples.advanced/ButtonFiberLedPrintTickerTimeP.em.zig
+++ b/workspace/em.core/em.examples.advanced/ButtonFiberLedPrintTickerTimeP.em.zig
@@ -98,10 +98,6 @@ pub const EM__TARG = struct {
             em.print("Short button press: Setting rate to {}x\n", .{dividedBy});
             em.print("... deltaAppCount should be {} - {}\n", .{ dividedBy * printTicks / maxAppLedTicks, (dividedBy * printTicks / maxAppLedTicks) + 1 });
             em.print("... deltaSysCount should be {} - {}\n", .{ dividedBy * printTicks / maxSysLedTicks, (dividedBy * printTicks / maxSysLedTicks) + 1 });
-            appTicker.stop();
-            sysTicker.stop();
-            lastAppCount = 0;
-            lastSysCount = 0;
             appTicker.start(maxAppLedTicks / dividedBy, &appTickCb);
             sysTicker.start(maxSysLedTicks / dividedBy, &sysTickCb);
         }

--- a/workspace/em.core/em.examples.advanced/ButtonFiberLedPrintTickerTimeP.em.zig
+++ b/workspace/em.core/em.examples.advanced/ButtonFiberLedPrintTickerTimeP.em.zig
@@ -1,0 +1,96 @@
+pub const em = @import("../../zigem/em.zig");
+pub const em__U = em.module(@This(), .{});
+pub const em__C = em__U.config(EM__CONFIG);
+
+pub const EM__CONFIG = struct {
+    appTicker: em.Param(TickerMgr.Obj),
+    sysTicker: em.Param(TickerMgr.Obj),
+    printTicker: em.Param(TickerMgr.Obj),
+};
+
+pub const AppBut = em.import.@"em__distro/BoardC".AppBut;
+pub const AppLed = em.import.@"em__distro/BoardC".AppLed;
+pub const EpochTime = em.import.@"em.utils/EpochTime";
+pub const FiberMgr = em.import.@"em.utils/FiberMgr";
+pub const TickerMgr = em.import.@"em.utils/TickerMgr";
+pub const SysLed = em.import.@"em__distro/BoardC".SysLed;
+
+pub const EM__META = struct {
+    pub fn em__constructH() void {
+        em__C.appTicker.set(TickerMgr.createH());
+        em__C.sysTicker.set(TickerMgr.createH());
+        em__C.printTicker.set(TickerMgr.createH());
+    }
+};
+
+pub const EM__TARG = struct {
+    //
+    const appTicker = em__C.appTicker;
+    const sysTicker = em__C.sysTicker;
+    const printTicker = em__C.printTicker;
+
+    const maxSysLedTicks: u32 = 384; // 1.5s
+    const maxAppLedTicks: u32 = 512; // 2s
+    const minPressTime = 10; // 10ms
+    const maxPressTime = 2000; // 2s
+    var dividedBy: u32 = 1;
+
+    var sysCount: u32 = 0;
+    var appCount: u32 = 0;
+    var lastAppCount: u32 = 0;
+    var lastSysCount: u32 = 0;
+    var printCount: u32 = 0;
+
+    pub fn em__run() void {
+        AppBut.onPressed(onButtonPressed, .{ .min = minPressTime, .max = maxPressTime });
+        appTicker.start(maxAppLedTicks, &appTickCb);
+        sysTicker.start(maxSysLedTicks, &sysTickCb);
+        printTicker.start(1024, &printTickCb);
+        FiberMgr.run();
+    }
+
+    fn appTickCb(_: TickerMgr.CallbackArg) void {
+        appCount += 1;
+        AppLed.wink(10);
+    }
+
+    fn sysTickCb(_: TickerMgr.CallbackArg) void {
+        sysCount += 1;
+        SysLed.wink(10);
+    }
+
+    fn printTickCb(_: TickerMgr.CallbackArg) void {
+        printCount += 1;
+        var subSeconds: u32 = 0;
+        const seconds = EpochTime.getCurrent(&subSeconds);
+        em.print("{}: Hello World: Rate={}x appCount={} sysCount={}\n", .{ seconds, dividedBy, appCount, sysCount });
+        if (dividedBy > 0 and lastSysCount > 0 and lastSysCount == sysCount) {
+            em.print("Sys ticker count did not increment\n", .{});
+            em.halt();
+        }
+        if (dividedBy > 0 and lastAppCount > 0 and lastAppCount == appCount) {
+            em.print("App ticker count did not increment\n", .{});
+            em.halt();
+        }
+        lastAppCount = appCount;
+        lastSysCount = sysCount;
+    }
+
+    pub fn onButtonPressed(_: AppBut.OnPressedCbArg) void {
+        if (AppBut.isPressed()) {
+            // a long press (press time > maxPressTime)
+            em.print("Long button press: Stopping app/sys tickers\n", .{});
+            dividedBy = 0;
+            appTicker.stop();
+            sysTicker.stop();
+            lastAppCount = 0;
+            lastSysCount = 0;
+        } else {
+            // a short press (minPressTime < press time < maxPressTime)
+            dividedBy = if (dividedBy >= 8 or dividedBy < 1) 1 else dividedBy * 2;
+            em.print("Short button press: Setting rate to {}x\n", .{dividedBy});
+            appTicker.start(maxAppLedTicks / dividedBy, &appTickCb);
+            sysTicker.start(maxSysLedTicks / dividedBy, &sysTickCb);
+        }
+    }
+};

--- a/workspace/em.core/em.examples.advanced/ButtonFiberLedPrintTickerTimeP.em.zig
+++ b/workspace/em.core/em.examples.advanced/ButtonFiberLedPrintTickerTimeP.em.zig
@@ -70,7 +70,11 @@ pub const EM__TARG = struct {
         const seconds = EpochTime.getCurrent(&subSeconds);
         const deltaAppCount = appCount - lastAppCount;
         const deltaSysCount = sysCount - lastSysCount;
-        em.print("{}: Hello World: Rate={}x deltaAppCount={} deltaSysCount={}\n", .{ seconds, dividedBy, deltaAppCount, deltaSysCount });
+        const minDeltaAppCount = dividedBy * printTicks / maxAppLedTicks;
+        const minDeltaSysCount = dividedBy * printTicks / maxSysLedTicks;
+        const deltaAppErr = if (deltaAppCount < minDeltaAppCount or deltaAppCount > minDeltaAppCount + 1) "*" else "";
+        const deltaSysErr = if (deltaSysCount < minDeltaSysCount or deltaSysCount > minDeltaSysCount + 1) "*" else "";
+        em.print("{}: Hello World: Rate={}x deltaAppCount={}{s} deltaSysCount={}{s}\n", .{ seconds, dividedBy, deltaAppCount, deltaAppErr, deltaSysCount, deltaSysErr });
         if (dividedBy > 0 and lastSysCount > 0 and lastSysCount == sysCount) {
             em.print("Sys ticker count did not increment\n", .{});
             em.halt();

--- a/workspace/em.core/em.utils/AlarmMgr.em.zig
+++ b/workspace/em.core/em.utils/AlarmMgr.em.zig
@@ -48,6 +48,7 @@ pub const EM__TARG = struct {
     var cur_alarm: ?*Alarm = null;
 
     fn findNextAlarm(delta_ticks: u32) void {
+        WakeupTimer.disable();
         const alarm_tab = em__C.AlarmOF;
         var nxt_alarm: ?*Alarm = null;
         var max_ticks = ~@as(u32, 0); // largest u32
@@ -66,7 +67,6 @@ pub const EM__TARG = struct {
     }
 
     fn wakeupHandler(_: WakeupTimer.HandlerArg) void {
-        WakeupTimer.disable();
         const alarm_tab = em__C.AlarmOF;
         const thresh: u32 = cur_alarm.?._thresh;
         for (0..alarm_tab.len) |idx| {

--- a/workspace/em.core/em.utils/AlarmMgr.em.zig
+++ b/workspace/em.core/em.utils/AlarmMgr.em.zig
@@ -17,7 +17,6 @@ pub const Alarm = struct {
     _fiber: FiberMgr.Obj,
     _thresh: u32 = 0, // time of alarm
     _dticks: u32 = 0, // delta ticks until alarm (0 == alarm inactive)
-    _idx: u8,
     pub fn active(self: *Self) bool {
         em__U.scope().Alarm_active(self);
     }
@@ -36,11 +35,8 @@ pub const EM__META = struct {
     //
     pub const WakeupTimer = em__C.WakeupTimer;
 
-    var cur_idx: u8 = 0;
-
     pub fn createH(fiber: FiberMgr.Obj) Obj {
-        cur_idx += 1;
-        const alarm = em__C.AlarmOF.createH(.{ ._fiber = fiber, ._idx = cur_idx });
+        const alarm = em__C.AlarmOF.createH(.{ ._fiber = fiber });
         return alarm;
     }
 };

--- a/workspace/em.core/em.utils/AlarmMgr.em.zig
+++ b/workspace/em.core/em.utils/AlarmMgr.em.zig
@@ -16,7 +16,8 @@ pub const Alarm = struct {
     const Self = @This();
     _fiber: FiberMgr.Obj,
     _thresh: u32 = 0, // time of alarm
-    _ticks: u32 = 0, // ticks remaining until alarm (0 == alarm inactive)
+    _dticks: u32 = 0, // delta ticks until alarm (0 == alarm inactive)
+    _idx: u8,
     pub fn active(self: *Self) bool {
         em__U.scope().Alarm_active(self);
     }
@@ -35,8 +36,11 @@ pub const EM__META = struct {
     //
     pub const WakeupTimer = em__C.WakeupTimer;
 
+    var cur_idx: u8 = 0;
+
     pub fn createH(fiber: FiberMgr.Obj) Obj {
-        const alarm = em__C.AlarmOF.createH(.{ ._fiber = fiber });
+        cur_idx += 1;
+        const alarm = em__C.AlarmOF.createH(.{ ._fiber = fiber, ._idx = cur_idx });
         return alarm;
     }
 };
@@ -54,33 +58,38 @@ pub const EM__TARG = struct {
         var max_ticks = ~@as(u32, 0); // largest u32
         for (0..alarm_tab.len) |idx| {
             var a = &alarm_tab[idx];
-            a._ticks -|= delta_ticks;
-            if (a._ticks > 0 and a._ticks < max_ticks) {
+            a._dticks -|= delta_ticks;
+            if (a._dticks > 0 and a._dticks < max_ticks) {
                 nxt_alarm = a;
-                max_ticks = a._ticks;
+                max_ticks = a._dticks;
             }
         }
         cur_alarm = nxt_alarm;
-        if (cur_alarm != null) {
-            WakeupTimer.enable(cur_alarm.?._thresh, &wakeupHandler);
+        if (cur_alarm) |ca| {
+            em.@"%%[a:]"(1);
+            em.@"%%[>]"(ca._idx);
+            em.@"%%[>]"(ca._thresh);
+            WakeupTimer.enable(ca._thresh, &wakeupHandler);
         }
     }
 
     fn wakeupHandler(_: WakeupTimer.HandlerArg) void {
+        em.@"%%[a]"();
+        em.@"%%[>]"(cur_alarm.?._idx);
         const alarm_tab = em__C.AlarmOF;
         const thresh: u32 = cur_alarm.?._thresh;
         for (0..alarm_tab.len) |idx| {
             var a = &alarm_tab[idx];
-            if (a._ticks > 0 and thresh == a._thresh) {
-                a._ticks = 0;
+            if (a._dticks > 0 and thresh == a._thresh) {
+                a._dticks = 0;
                 a._fiber.post(); // ring the alarm
             }
         }
-        findNextAlarm(cur_alarm.?._ticks);
+        findNextAlarm(cur_alarm.?._dticks);
     }
 
     pub fn Alarm_cancel(alarm: *Alarm) void {
-        alarm._ticks = 0;
+        alarm._dticks = 0;
         findNextAlarm(0);
     }
 
@@ -90,7 +99,11 @@ pub const EM__TARG = struct {
 
     fn Alarm_setup(alarm: *Alarm, ticks: u32) void {
         alarm._thresh = WakeupTimer.ticksToThresh(ticks);
-        alarm._ticks = ticks;
+        alarm._dticks = ticks;
+        //em.@"%%[a:]"(2);
+        //em.@"%%[>]"(alarm._idx);
+        //em.@"%%[>]"(alarm._dticks);
+        //em.@"%%[>]"(alarm._thresh);
         findNextAlarm(0);
     }
 
@@ -104,6 +117,8 @@ pub const EM__TARG = struct {
         const et_secs = EpochTime.getCurrent(&et_subs);
         const et_ticks = WakeupTimer.timeToTicks(et_secs, et_subs);
         const ticks = WakeupTimer.secs256ToTicks(secs256);
-        Alarm_setup(alarm, ticks - (et_ticks % ticks));
+        const rem = et_ticks % ticks;
+        Alarm_setup(alarm, ticks - rem);
+        // em.print("ticks = {d}, et_ticks = {d} , rem = {d}\n", .{ ticks, et_ticks, rem });
     }
 };

--- a/workspace/em.core/em.utils/AlarmMgr.em.zig
+++ b/workspace/em.core/em.utils/AlarmMgr.em.zig
@@ -48,7 +48,6 @@ pub const EM__TARG = struct {
     var cur_alarm: ?*Alarm = null;
 
     fn findNextAlarm(delta_ticks: u32) void {
-        WakeupTimer.disable();
         const alarm_tab = em__C.AlarmOF;
         var nxt_alarm: ?*Alarm = null;
         var max_ticks = ~@as(u32, 0); // largest u32
@@ -67,6 +66,7 @@ pub const EM__TARG = struct {
     }
 
     fn wakeupHandler(_: WakeupTimer.HandlerArg) void {
+        WakeupTimer.disable();
         const alarm_tab = em__C.AlarmOF;
         const thresh: u32 = cur_alarm.?._thresh;
         for (0..alarm_tab.len) |idx| {


### PR DESCRIPTION
Fixes bugs in AlarmMgr.

Adds a combo example that runs three interval timers (aka tickers):
- The tickers run a different relative rates so that they collide sometimes and don't others.
- one fires the App LED when hit
- one fires the Sys LED when hit
- one fires the APP Out print when hit and prints status messages.

Uses the button to vary the rate of the two LED tickers.  The print ticker rate remains constant (1/4 Hz).
- Short press (10ms < press time < 2s) - rotates between 1x, 2x, 4x, 8x on the ticker rates.
- Long press (>2s) - stops the two LED tickers altogether.

If the LED tickers are running, and they don't happen during the print ticker interval, then the program will flag the error on the APP out UART, and halt -- yielding a solid red LED.  This is an error condition that should never occur because the print ticker rate is long compared to the LED tickers.  So at least one LED tick should happen between print ticks.

Hence we can use this as an operational test.
