### PR TITLE
add EpochTime.msecsFromSubs()

### DIFF
--- a/workspace/em.core/em.utils/AlarmMgr.em.zig
+++ b/workspace/em.core/em.utils/AlarmMgr.em.zig
@@ -99,7 +99,7 @@ pub const EM__TARG = struct {
 
     pub fn Alarm_wakeupAt(alarm: *Alarm, secs256: u32) void {
         var et_subs: u32 = undefined;
-        const et_secs = EpochTime.getCurrent(&et_subs);
+        const et_secs = EpochTime.getRawTime(&et_subs);
         const et_ticks = WakeupTimer.timeToTicks(et_secs, et_subs);
         const ticks = WakeupTimer.secs256ToTicks(secs256);
         const rem = et_ticks % ticks;

--- a/workspace/em.core/em.utils/EpochTime.em.zig
+++ b/workspace/em.core/em.utils/EpochTime.em.zig
@@ -14,9 +14,13 @@ pub const EM__TARG = struct {
     //
     const Uptimer = em__C.Uptimer.scope();
 
-    pub fn getCurrent(o_subs: *u32) u32 {
+    pub fn getRawTime(o_subs: *u32) u32 {
         const time = Uptimer.read();
         o_subs.* = time.subs;
         return time.secs;
+    }
+
+    pub fn msecsFromSubs(subs: u32) u32 {
+        return ((subs >> 24) * 1000) / 256;
     }
 };


### PR DESCRIPTION
Fixes #23

also renamed EpochTime.getCurrent() to EpochTime.getRawTime()