### PR TITLE
Fix conversion error from sub_seconds to milliseconds

### DIFF
--- a/workspace/em.core/em.utils/EpochTime.em.zig
+++ b/workspace/em.core/em.utils/EpochTime.em.zig
@@ -21,6 +21,6 @@ pub const EM__TARG = struct {
     }
 
     pub fn msecsFromSubs(subs: u32) u32 {
-        return ((subs >> 24) * 1000) / 256;
+        return ((subs >> 16) * 1000) / 65536;
     }
 };


### PR DESCRIPTION
I noticed that the ms seemed odd.  When comparing to what was in sub_seconds, it had been ignoring eight bits of sub_seconds in its calculation.  The code here fixes that issue.